### PR TITLE
Fixed issue with tagging on Firefox

### DIFF
--- a/src/scania-angular-ui.js
+++ b/src/scania-angular-ui.js
@@ -193,6 +193,7 @@
                         options.data = { results: JSON.parse($attr.data), text: $attr.label };
                         options.createSearchChoice = $scope.createSearchChoice;
                         options.tokenSeparators = $scope.tokenSeparators || tokenSeparators;
+                        options.id = $attr.itemId;
                         inputOptionsLabelProperty = options.label;
                     }
                     select = $(tag + '.sc-' + selectorName + '[id="' + $attr.id + '"]');


### PR DESCRIPTION
Added the "id" property on the options object that we pass to the
select2 library